### PR TITLE
Generate relative url (without host) instead absolute url 

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -97,7 +97,7 @@
                 {% endblock %}
                 {% block logo %}
                     {% spaceless %}
-                    <a class="logo" href="{{ url('sonata_admin_dashboard') }}">
+                    <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
                         {% if 'single_image' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
                             <img src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                         {% endif %}
@@ -153,7 +153,7 @@
                             {% block sonata_side_nav %}
                                 {% block sonata_sidebar_search %}
                                     {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
-                                        <form action="{{ url('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
+                                        <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                             <div class="input-group custom-search-form">
                                                 <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
                                                     <span class="input-group-btn">

--- a/Resources/views/standard_layout.html.twig
+++ b/Resources/views/standard_layout.html.twig
@@ -109,7 +109,7 @@
                 {% block logo %}
                     {% if admin_pool is defined %}
                         {% spaceless %}
-                            <a class="logo" href="{{ url('sonata_admin_dashboard') }}">
+                            <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
                                 {% if 'single_image' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
                                     <img src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                                 {% endif %}
@@ -161,7 +161,7 @@
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
                                 {% if app.security.token and is_granted('ROLE_SONATA_ADMIN') %}
-                                    <form action="{{ url('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
+                                    <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
                                             <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
                                                 <span class="input-group-btn">


### PR DESCRIPTION
Replaced "url" with "path" in twig templates.

Problem was that in development environment URLs generated by url function were pointing to production instance when site entity property "host" was set to production host name. This was causing confusion when using certain links on different than production environment.
