### PR TITLE
simplified publication process of single page

### DIFF
--- a/Resources/views/Button/publish_button.html.twig
+++ b/Resources/views/Button/publish_button.html.twig
@@ -1,0 +1,5 @@
+{% if admin.id(object) and admin.child('sonata.page.admin.snapshot').isGranted('CREATE') %}
+    <a class="btn btn-default sonata-action-element" href="{{ admin.child('sonata.page.admin.snapshot').generateUrl('create', {'pageId': object.id, 'create': 1}) }}">
+        <i class="fa fa-cloud-upload "></i>
+        {{ 'orangegate.link_action_publish'|trans }}</a>
+{% endif %}

--- a/Resources/views/CRUD/base_edit.html.twig
+++ b/Resources/views/CRUD/base_edit.html.twig
@@ -14,10 +14,13 @@
 
 {% block actions %}
     <div class="btn-group">{% spaceless %}
-        {% include 'SymbioOrangeGateAdminBundle:Button:show_button.html.twig' %}
-        {% include 'SymbioOrangeGateAdminBundle:Button:history_button.html.twig' %}
-        {% include 'SymbioOrangeGateAdminBundle:Button:acl_button.html.twig' %}
-    {% endspaceless %}</div>
+            {% include 'SymbioOrangeGateAdminBundle:Button:show_button.html.twig' %}
+            {% include 'SymbioOrangeGateAdminBundle:Button:history_button.html.twig' %}
+            {% if admin.code == 'sonata.page.admin.page' and admin.child('sonata.page.admin.snapshot').isGranted('CREATE')%}
+                {% include 'SymbioOrangeGateAdminBundle:Button:publish_button.html.twig' %}
+            {% endif %}
+            {% include 'SymbioOrangeGateAdminBundle:Button:acl_button.html.twig' %}
+        {% endspaceless %}</div>
     {#% include 'SymbioOrangeGateAdminBundle:Button:list_button.html.twig' %#}
 {% endblock %}
 

--- a/Resources/views/CRUD/base_list.html.twig
+++ b/Resources/views/CRUD/base_list.html.twig
@@ -2,7 +2,9 @@
 
 {% block actions %}
 {% spaceless %}
-    {% include 'SymbioOrangeGateAdminBundle:Button:create_button.html.twig' %}
+    {% if admin.code != 'sonata.page.admin.snapshot' %}
+        {% include 'SymbioOrangeGateAdminBundle:Button:create_button.html.twig' %}
+    {% endif %}
 {% endspaceless %}
 {% endblock %}
 


### PR DESCRIPTION
I created publish button and included in edit page of PageAdmin. Also I removed create button from SnapshotAdmin list template, because we want simplifier publication process of single page through publish button and create button is redundant now. 

Important note:
This pull request is tied with pull request in orangegate4-page-bundle
